### PR TITLE
Adding Time Sleep and Editing the README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ testacc:
 hard_apply:
 	rm -rf examples/.terraform                                                          
 	rm -rf examples/.terraform.lock.hcl
-	rm -rf examples/.terraform
 	rm -rf ~/.terraform.d/plugins/
 	rm -rf examples/terraform.log
 	rm -rf examples/terraform.tfstate

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,14 @@ test:
 
 testacc: 
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
+
+hard_apply:
+	rm -rf examples/.terraform                                                          
+	rm -rf examples/.terraform.lock.hcl
+	rm -rf examples/.terraform
+	rm -rf ~/.terraform.d/plugins/
+	rm -rf examples/terraform.log
+	rm -rf examples/terraform.tfstate
+	rm -rf examples/terraform.tfstate.backup
+	make install
+	cd examples && terraform init && terraform apply && cd ..

--- a/README.md
+++ b/README.md
@@ -42,17 +42,16 @@ export PREFECT_ACCOUNT_ID="<YOUR-ACCOUNT-ID>"
 ```
 
 ### 3. Set your CPU architecture
-This step is necessary to build the provider with 
-
-### 4. Build the provider
-This builds the providers's binary and move it to the Terraform plugins directory (usually under `~/.terraform.d/plugins/`)
-
-Before building the provider make sure you've set the correct CPU architecture of your machine.  
-E.g: for MAC M1, use `darwin_arm64`, for MAC Intel use `darwin_amd64`.  
+Make sure you've set the correct CPU architecture of your machine. This step is necessary to build the provider with.
+E.g: For Mac M1, use `darwin_arm64`, for Mac Intel use `darwin_amd64`.  
 ```
 export CPU_ARCHITECTURE="darwin_arm64"
 ```
-Now run the `make` command to build the provider:
+
+### 4. Build the provider
+This builds the providers's binary and move it to the Terraform plugins directory (usually under `~/.terraform.d/plugins/`) 
+
+Run the `make` command to build the provider:
 ```
 make install
 ```

--- a/examples/data_sources.tf
+++ b/examples/data_sources.tf
@@ -23,11 +23,17 @@
 data "prefect2_block_types" "s3_block_type" {
     workspace_id = prefect2_workspace.terraform-workspace.id
     slug = "s3"
+    depends_on = [
+        time_sleep.wait_for_prefect2_workspace
+    ]
 }
 
 data "prefect2_block_schemas" "s3_block_schema" {
     workspace_id = prefect2_workspace.terraform-workspace.id
     checksum = "sha256:77690b4ef54ef3edc93fca6ac54bc540a32ca07169e91aecd36e49b2e1eeebc5"
+    depends_on = [
+        time_sleep.wait_for_prefect2_workspace
+    ]
 }
 
 # KubernetesJob block type and schema (helpers)
@@ -35,9 +41,15 @@ data "prefect2_block_schemas" "s3_block_schema" {
 data "prefect2_block_types" "kubernetes_job_block_type" {
     workspace_id = prefect2_workspace.terraform-workspace.id
     slug = "kubernetes-job"
+    depends_on = [
+        time_sleep.wait_for_prefect2_workspace
+    ]
 }
 
 data "prefect2_block_schemas" "kubernetes_job_block_schema" {
     workspace_id = prefect2_workspace.terraform-workspace.id
     checksum = "sha256:1a553852c1bcc9cd95645917bdbaaae9e28cbcc1270ff5b43b45bbd87564f5cc"
+    depends_on = [
+        time_sleep.wait_for_prefect2_workspace
+    ]
 }

--- a/examples/resources.tf
+++ b/examples/resources.tf
@@ -36,7 +36,7 @@ resource "prefect2_block" "terraform-kubernetes-job-block" {
 }
 
 resource "time_sleep" "wait_for_prefect2_workspace" {
-    create_duration = "2s"
+    create_duration = "3s"
     depends_on = [
       prefect2_workspace.terraform-workspace
     ]

--- a/examples/resources.tf
+++ b/examples/resources.tf
@@ -34,3 +34,10 @@ resource "prefect2_block" "terraform-kubernetes-job-block" {
         image = "123456789123.dkr.ecr.eu-west-1.amazonaws.com/kubernetes-job-block:latest"
     }
 }
+
+resource "time_sleep" "wait_for_prefect2_workspace" {
+    create_duration = "2s"
+    depends_on = [
+      prefect2_workspace.terraform-workspace
+    ]
+}


### PR DESCRIPTION
When running `terraform apply` for the first time, I would hit a `Block not found error` as some data sources require `terraform-workspace.id`. This was due to a lag in passing the ID (generated from  Prefect2's API) to the next data source. Using Terraform's `time.sleep` resource and `depends_on`, we can give the resource time to be ready for use.

Other edits include better readability of the README and the new make command `hard_apply` which removes terraform files and runs `terraform apply`.